### PR TITLE
Disable reporting the error to the chat

### DIFF
--- a/instantview/hooks.py
+++ b/instantview/hooks.py
@@ -72,8 +72,6 @@ def on_msg(bot: Bot, accid: int, event: NewMsgEvent) -> None:
             send_preview(bot, accid, msg, url)
         except Exception as ex:
             bot.logger.exception(ex)
-            reply = MsgData(text=f"Error: {ex}", quoted_message_id=msg.id)
-            bot.rpc.send_msg(accid, msg.chat_id, reply)
 
 
 @cli.on(events.NewMessage(command="/help"))


### PR DESCRIPTION
This could probably be wrapped in something that checks for an ENV or a development/debug flag so the errors still get reported, but it shouldn't be happening by default.

#1 